### PR TITLE
Use vscode clipboard API for copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,9 @@
 {
   "name": "copy-json-path",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/copy-paste": {
-      "version": "1.1.30",
-      "resolved": "https://registry.npmjs.org/@types/copy-paste/-/copy-paste-1.1.30.tgz",
-      "integrity": "sha1-p9RUyeHkVCMo9/Huz1Mzvoz7UO0="
-    },
     "@types/mocha": {
       "version": "2.2.48",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -218,15 +213,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "copy-paste": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/copy-paste/-/copy-paste-1.3.0.tgz",
-      "integrity": "sha1-p+bEocKP3t8rCB5yuX3y75X0ce0=",
-      "requires": {
-        "iconv-lite": "^0.4.8",
-        "sync-exec": "~0.6.x"
-      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -495,14 +481,6 @@
       "requires": {
         "agent-base": "^4.3.0",
         "debug": "^3.1.0"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "inflight": {
@@ -932,7 +910,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "semver": {
       "version": "5.5.0",
@@ -1033,12 +1012,6 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
-    },
-    "sync-exec": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/sync-exec/-/sync-exec-0.6.2.tgz",
-      "integrity": "sha1-cX0izFPwzh3vVZQ2LzqJouu5EQU=",
-      "optional": true
     },
     "tough-cookie": {
       "version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,6 @@
     "vscode": "^1.0.0"
   },
   "dependencies": {
-    "@types/copy-paste": "^1.1.30",
-    "acorn": "^5.7.1",
-    "copy-paste": "^1.3.0"
+    "acorn": "^5.7.1"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,6 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode'
 import {jsPathTo} from './jsPathTo'
-import * as ncp from 'copy-paste'
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -26,9 +25,7 @@ export function activate(context: vscode.ExtensionContext) {
             const text = editor.document.getText()
             // JSON.parse(text)
             const path = jsPathTo(text, editor.document.offsetAt(editor.selection.active))
-            ncp.copy(path, () => {
-                // vscode.window.showInformationMessage(`Path "${path}" copied to clipboard.`)
-            })
+            vscode.env.clipboard.writeText(path)
         } catch (ex) {
             if (ex instanceof SyntaxError) {
                 vscode.window.showErrorMessage(`Invalid JSON.`)


### PR DESCRIPTION
### Summary
Use VSCode's Clipboard API (https://code.visualstudio.com/api/references/vscode-api#Clipboard) for copy operation.

This allow the extension to be compatible with more system / environment.

The dependency `copy-paste` is thus no longer needed and can be removed.

Likely addresses https://github.com/nidu/vscode-copy-json-path/issues/2 too

### Motivation

This extension doesn't work in VS Code Remote WSL (Ubuntu) and VS Code Remote Container (alpine 3.11.7) environment.

However, no error is thrown in either environment when it fails to copy.

Installing xclip as suggested in https://github.com/nidu/vscode-copy-json-path/issues/2#issuecomment-399585068 doesn't help. In these environment xclip throws "Error: Can't open display: (null)"

### How is this tested?

Tested in VS Code Remote Docker environment (container: alpine 3.11.7)